### PR TITLE
fix: fix incorrect pipeline trigged ON-5965

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -73,6 +73,7 @@ services:
         ELASTIC_VERSION: ${ELASTIC_VERSION}
     volumes:
       - ./logstash/config/logstash.yml:/usr/share/logstash/config/logstash.yml:ro,Z
+      - ./logstash/config/pipelines.yml:/usr/share/logstash/config/pipelines.yml:ro,Z
       - ./logstash/pipeline:/usr/share/logstash/pipeline:ro,Z
       - ./plugins:/usr/share/logstash/plugins:ro,Z
     command: >

--- a/logstash/config/pipelines.yml
+++ b/logstash/config/pipelines.yml
@@ -1,0 +1,11 @@
+- pipeline.id: job_profile_sync
+  path.config: "/usr/share/logstash/pipeline/job-profile-sync.conf"
+  pipeline.workers: 1
+
+- pipeline.id: job_listing_sync
+  path.config: "/usr/share/logstash/pipeline/job-listing-sync.conf"
+  pipeline.workers: 1
+
+- pipeline.id: main
+  path.config: "/usr/share/logstash/pipeline/logstash.conf"
+  pipeline.workers: 1


### PR DESCRIPTION
Linktask: https://oncircle.atlassian.net/browse/ON-5965
This pull request includes changes to the `docker-compose.yml` and `logstash/config/pipelines.yml` files to enhance the configuration of Logstash pipelines.

Enhancements to Logstash configuration:

* [`docker-compose.yml`](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3R76): Added a new volume mapping for `pipelines.yml` to the Logstash service configuration.
* [`logstash/config/pipelines.yml`](diffhunk://#diff-b17eab13219c6753350d12f2f01a85f02301e73592ea0d104a8d2e7ac16038ceR1-R11): Added configurations for three pipelines (`job_profile_sync`, `job_listing_sync`, and `main`), specifying their IDs, configuration paths, and the number of workers.