### PR TITLE
ON-7170 fix: job profile sync with ngram tokenizer (to search partial word) and support to search with new field (bio, education desc) and job skills

### DIFF
--- a/elasticsearch/index/circle-job-profiles.json
+++ b/elasticsearch/index/circle-job-profiles.json
@@ -8,17 +8,28 @@
           "updateable": true
         }
       },
+      "tokenizer": {
+        "ngram_tokenizer": {
+          "type": "ngram",
+          "min_gram": 1,
+          "max_gram": 2,
+          "token_chars": [
+            "letter",
+            "digit"
+          ]
+        }
+      },
       "analyzer": {
         "default_analyzer": {
           "type": "custom",
-          "tokenizer": "standard",
+          "tokenizer": "ngram_tokenizer",
           "filter": [
             "lowercase"
           ]
         },
         "job_search_analyzer": {
           "type": "custom",
-          "tokenizer": "standard",
+          "tokenizer": "ngram_tokenizer",
           "filter": [
             "lowercase",
             "synonym_filter"
@@ -167,11 +178,27 @@
         }
       },
       "bio": {
-        "type": "keyword"
+        "type": "text",
+            "analyzer": "default_analyzer",
+            "search_analyzer": "job_search_analyzer",
+            "fields": {
+              "keyword": {
+                "type": "keyword",
+                "ignore_above": 256
+              }
+        }
       },
       "education_description": {
-        "type": "keyword"
-      },
+        "type": "text",
+            "analyzer": "default_analyzer",
+            "search_analyzer": "job_search_analyzer",
+            "fields": {
+              "keyword": {
+                "type": "keyword",
+                "ignore_above": 256
+              }
+        }
+      },  
       "is_authorized_to_work_in_us": {
         "type": "boolean"
       },
@@ -192,6 +219,8 @@
           },
           "bio": {
             "type": "text",
+            "analyzer": "default_analyzer",
+            "search_analyzer": "job_search_analyzer",
             "fields": {
               "keyword": {
                 "type": "keyword",
@@ -318,6 +347,8 @@
           },
           "name": {
             "type": "text",
+            "analyzer": "default_analyzer",
+            "search_analyzer": "job_search_analyzer",
             "fields": {
               "keyword": {
                 "type": "keyword",
@@ -513,6 +544,36 @@
           },
           "job_position_id": {
             "type": "keyword"
+          }
+        }
+      },
+      "job_skills": {
+        "type": "nested",
+        "properties": {
+          "id": {
+            "type": "text"
+          },
+          "name": {
+            "type": "text",
+            "analyzer": "default_analyzer",
+            "search_analyzer": "job_search_analyzer",
+            "fields": {
+              "keyword": {
+                "type": "keyword",
+                "ignore_above": 256
+              }
+            }
+          },
+          "type": {
+           "type": "text",
+            "analyzer": "default_analyzer",
+            "search_analyzer": "job_search_analyzer",
+            "fields": {
+              "keyword": {
+                "type": "keyword",
+                "ignore_above": 256
+              }
+           }
           }
         }
       },

--- a/elasticsearch/index/circle-job-profiles.json
+++ b/elasticsearch/index/circle-job-profiles.json
@@ -440,7 +440,6 @@
         "type": "keyword"
       },
       "preferred_positions": {
-        "type": "nested",
         "properties": {
           "job_position": {
             "properties": {
@@ -503,42 +502,34 @@
               "parent_id": {
                 "type": "keyword"
               },
-              "translations": {
-                "properties": {
-                  "created_at": {
-                    "type": "date"
-                  },
-                  "id": {
-                    "type": "keyword"
-                  },
-                  "job_position_id": {
-                    "type": "keyword"
-                  },
-                  "language": {
-                    "type": "text",
-                    "fields": {
-                      "keyword": {
-                        "type": "keyword",
-                        "ignore_above": 256
-                      }
-                    }
-                  },
-                  "translation": {
-                    "type": "text",
-                    "fields": {
-                      "keyword": {
-                        "type": "keyword",
-                        "ignore_above": 256
-                      }
-                    }
-                  },
-                  "updated_at": {
-                    "type": "date"
+              "updated_at": {
+                "type": "date"
+              }
+            }
+          },
+          "translations": {
+            "properties": {
+              "include_position_names": {
+               "type": "text",
+               "analyzer": "default_analyzer",
+               "search_analyzer": "job_search_analyzer",
+                "fields": {
+                  "keyword": {
+                    "type": "keyword",
+                    "ignore_above": 256
                   }
                 }
               },
-              "updated_at": {
-                "type": "date"
+              "name": {
+                "type": "text",
+                "analyzer": "default_analyzer",
+                "search_analyzer": "job_search_analyzer",
+                "fields": {
+                  "keyword": {
+                    "type": "keyword",
+                    "ignore_above": 256
+                  }
+                }
               }
             }
           },
@@ -548,7 +539,6 @@
         }
       },
       "job_skills": {
-        "type": "nested",
         "properties": {
           "id": {
             "type": "text"

--- a/elasticsearch/ingest-pipeline/circle-job-profiles.json
+++ b/elasticsearch/ingest-pipeline/circle-job-profiles.json
@@ -33,6 +33,12 @@
         },
         "if": "ctx.lat != null && ctx.lng != null"
       }
+    },
+    {
+      "json": {
+        "field": "job_skills",
+        "if": "ctx.job_skills != []"
+      }
     }
   ]
 }

--- a/logstash/pipeline/job-profile-sync.conf
+++ b/logstash/pipeline/job-profile-sync.conf
@@ -138,7 +138,6 @@ LEFT JOIN LATERAL (
     WHERE je.job_profile_id = jp.id
 ) je ON true
 WHERE jp.updated_at > :sql_last_value AND jp.updated_at < CURRENT_TIMESTAMP
-and jp.id in ('3ee1da2e-6a27-4dd4-91a7-ba130ed8f768',  '87b83172-251e-4935-8c43-5c372e4ead42')
 ORDER BY jp.updated_at ASC
         "
     }

--- a/logstash/pipeline/job-profile-sync.conf
+++ b/logstash/pipeline/job-profile-sync.conf
@@ -19,6 +19,7 @@ input{
     COALESCE(jpp.preferred_positions, '[]'::jsonb)::text AS preferred_positions,
     COALESCE(jrr.referrals, '[]'::jsonb)::text AS referrals,
     COALESCE(je.experiences, '[]'::jsonb)::text AS experiences,
+    COALESCE(jps.js, '[]'::jsonb)::text AS job_skills,
     (
         SELECT 
             CONCAT(
@@ -77,6 +78,14 @@ input{
         WHERE jpp2.job_profile_id = jp.id
     ) AS description_vector
 FROM job_profiles jp
+
+LEFT JOIN LATERAL (
+	SELECT jsonb_agg(jsonb_build_object('name', js.name,'id', js.id, 'type', js.type )) as js
+			     FROM job_profile_skills jps
+			     JOIN job_skills js ON js.id = jps.job_skill_id
+			     WHERE jps.job_profile_id = jp.id
+) jps ON true
+
 JOIN users u ON u.id = jp.user_id
 LEFT JOIN LATERAL (
     SELECT 
@@ -129,6 +138,7 @@ LEFT JOIN LATERAL (
     WHERE je.job_profile_id = jp.id
 ) je ON true
 WHERE jp.updated_at > :sql_last_value AND jp.updated_at < CURRENT_TIMESTAMP
+and jp.id in ('3ee1da2e-6a27-4dd4-91a7-ba130ed8f768',  '87b83172-251e-4935-8c43-5c372e4ead42')
 ORDER BY jp.updated_at ASC
         "
     }


### PR DESCRIPTION
| Status  | Type  | Env Vars Change |
| :---: | :---: | :---: |
| Ready | Feature | No |
https://oncircle.atlassian.net/browse/ON-7170

## Problem

- Existing Elasticsearch configuration lacks flexible tokenization for improved search capabilities.
- Job profiles data handling does not efficiently include job skills, affecting data analysis and retrieval.

## Solution

- Introduced a custom "ngram_tokenizer" to the Elasticsearch index configuration for more granular text analysis.
- Modified field types and analyzers to improve search flexibility and accuracy.
- Updated job profile sync query to include job skills using JSON aggregation and improved query filtering.

## Test results
_Add your screenshots or recording about testing_

## Other changes 
- Reorganized "preferred_positions" structure by removing certain nested properties for streamlined data handling.

## Deploy Notes

There are no new dependencies, scripts, or environment variables introduced with this PR.